### PR TITLE
fix: support NodePort/non-ingress Helm deploys and fix secure cookie handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,34 @@ helm install gha-dashboard ./deploy/helm/gha-dashboard \
   --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
   --set jwt.secret=YOUR_JWT_SECRET \
   --set database.url='postgresql://user:pass@your-postgres-host:5432/gha_dashboard' \
+  --set ingress.enabled=true \
   --set ingress.host=gha-dashboard.your-domain.com
 ```
 
 `database.url` is stored in the Kubernetes Secret alongside other credentials. For production, use a managed PostgreSQL service (RDS, Cloud SQL, Azure Database, etc.) and set `database.url` to its connection string. If `database.url` is left empty, the backend falls back to in-memory view storage.
+
+### Deploying without an Ingress (NodePort or port-forward)
+
+When `ingress.enabled` is `false`, set `frontendUrl` explicitly so the OAuth redirect URI and CORS origin are correct:
+
+```bash
+helm install gha-dashboard ./deploy/helm/gha-dashboard \
+  --set github.appClientId=YOUR_APP_CLIENT_ID \
+  --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
+  --set jwt.secret=YOUR_JWT_SECRET \
+  --set frontend.service.type=NodePort \
+  --set frontendUrl=http://YOUR_NODE_HOSTNAME:NODE_PORT
+```
+
+`frontendUrl` defaults to the ingress host when not set. If you're on HTTP (not HTTPS), session cookies are automatically set without the `Secure` flag so they work in plain HTTP environments — `Secure` is only enabled when `frontendUrl` starts with `https://`.
+
+### Service type
+
+Both frontend and backend services default to `ClusterIP`. Override with `frontend.service.type` or `backend.service.type`:
+
+```bash
+--set frontend.service.type=NodePort
+```
 
 See `deploy/helm/gha-dashboard/values.yaml` for all configurable values (replicas, resources, TLS, GitHub Enterprise API URL, etc).
 
@@ -162,7 +186,7 @@ Users can install from the OCI registry directly:
 ```bash
 helm registry login ghcr.io
 helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
-  --version 1.0.0 \
+  --version 1.0.1 \
   --set github.appClientId=YOUR_APP_CLIENT_ID \
   --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
   --set jwt.secret=YOUR_JWT_SECRET \
@@ -195,7 +219,7 @@ Cache is per-user, keyed by `userId:endpoint`.
 ## GitHub App Setup
 
 1. Go to **Settings → Developer settings → GitHub Apps → New GitHub App**
-2. Set the **Callback URL** to `http://localhost:5173/api/auth/callback` (for local dev) or your production URL
+2. Set the **Callback URL** to `http://localhost:5173/api/auth/callback` (for local dev), your production URL, or `http://YOUR_NODE:PORT/api/auth/callback` for NodePort deployments. Must exactly match the `frontendUrl` Helm value + `/api/auth/callback`.
 3. Under **Permissions**:
    - Repository: **Actions** → Read-only, **Metadata** → Read-only (auto-selected)
    - Organization: **Members** → Read-only

--- a/deploy/helm/gha-dashboard/Chart.yaml
+++ b/deploy/helm/gha-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gha-dashboard
 description: GitHub Actions Dashboard - Monitor workflow statuses across organizations
 type: application
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.1.0
+appVersion: 1.0.1

--- a/deploy/helm/gha-dashboard/Chart.yaml
+++ b/deploy/helm/gha-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gha-dashboard
 description: GitHub Actions Dashboard - Monitor workflow statuses across organizations
 type: application
-version: 1.1.0
-appVersion: 1.0.1
+version: 1.0.1
+appVersion: "1.0.1"

--- a/deploy/helm/gha-dashboard/templates/configmap.yaml
+++ b/deploy/helm/gha-dashboard/templates/configmap.yaml
@@ -9,7 +9,10 @@ data:
   GITHUB_API_URL: {{ .Values.github.apiUrl | quote }}
   NODE_ENV: "production"
   PORT: {{ .Values.backend.service.port | quote }}
-  {{- if .Values.ingress.tls.enabled }}
+  {{- if .Values.frontendUrl }}
+  FRONTEND_URL: {{ .Values.frontendUrl | quote }}
+  CORS_ORIGIN: {{ .Values.frontendUrl | quote }}
+  {{- else if .Values.ingress.tls.enabled }}
   FRONTEND_URL: "https://{{ .Values.ingress.host }}"
   CORS_ORIGIN: "https://{{ .Values.ingress.host }}"
   {{- else }}

--- a/deploy/helm/gha-dashboard/templates/service-backend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-backend.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: backend
 spec:
-  type: ClusterIP
+  type: {{ .Values.backend.service.type }}
   ports:
     - port: {{ .Values.backend.service.port }}
       targetPort: {{ .Values.backend.service.port }}

--- a/deploy/helm/gha-dashboard/templates/service-backend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-backend.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: backend
 spec:
-  type: {{ .Values.backend.service.type }}
+  type: {{ default "ClusterIP" .Values.backend.service.type }}
   ports:
     - port: {{ .Values.backend.service.port }}
       targetPort: {{ .Values.backend.service.port }}

--- a/deploy/helm/gha-dashboard/templates/service-frontend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-frontend.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: frontend
 spec:
-  type: {{ .Values.frontend.service.type }}
+  type: {{ default "ClusterIP" .Values.frontend.service.type }}
   ports:
     - port: {{ .Values.frontend.service.port }}
       targetPort: 80

--- a/deploy/helm/gha-dashboard/templates/service-frontend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-frontend.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: frontend
 spec:
-  type: ClusterIP
+  type: {{ .Values.frontend.service.type }}
   ports:
     - port: {{ .Values.frontend.service.port }}
       targetPort: 80

--- a/deploy/helm/gha-dashboard/values.yaml
+++ b/deploy/helm/gha-dashboard/values.yaml
@@ -2,9 +2,10 @@ frontend:
   replicaCount: 1
   image:
     repository: ghcr.io/shayd3/gha-dashboard-frontend
-    tag: v1.0.0
+    tag: v1.0.1
     pullPolicy: IfNotPresent
   service:
+    type: ClusterIP
     port: 80
   resources:
     limits:
@@ -18,9 +19,10 @@ backend:
   replicaCount: 1
   image:
     repository: ghcr.io/shayd3/gha-dashboard-backend
-    tag: v1.0.0
+    tag: v1.0.1
     pullPolicy: IfNotPresent
   service:
+    type: ClusterIP
     port: 3000
   resources:
     limits:
@@ -37,6 +39,12 @@ ingress:
   tls:
     enabled: false
     secretName: gha-dashboard-tls
+
+# Override the URL used for OAuth redirect_uri and CORS origin.
+# Defaults to the ingress host when not set.
+# Required when ingress is disabled (e.g. NodePort or port-forward).
+# Example: "http://bread-bank:31515"
+frontendUrl: ""
 
 github:
   appClientId: ""

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gha-dashboard/backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/backend/src/__tests__/routes/auth.test.ts
+++ b/packages/backend/src/__tests__/routes/auth.test.ts
@@ -53,6 +53,21 @@ function mockFetchTokenFailure() {
 }
 
 /**
+ * Temporarily set FRONTEND_URL for the duration of the test callback,
+ * then restore the original value.
+ */
+async function withFrontendUrl<T>(url: string, fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.FRONTEND_URL;
+  process.env.FRONTEND_URL = url;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = prev;
+  }
+}
+
+/**
  * Perform the login redirect to get a valid state cookie,
  * then return the state value and cookie header string.
  */
@@ -128,6 +143,26 @@ describe("Auth routes", () => {
       const stateCookie = cookies.find((c) => c.includes("gha_oauth_state"));
       expect(stateCookie).toBeDefined();
     });
+
+    it("sets Secure flag on OAuth state cookie when FRONTEND_URL is https", async () => {
+      await withFrontendUrl("https://example.com", async () => {
+        const res = await app.inject({ method: "GET", url: "/api/auth/login" });
+        const setCookie = res.headers["set-cookie"] as string | string[];
+        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+        const stateCookie = cookies.find((c) => c.includes("gha_oauth_state"));
+        expect(stateCookie).toMatch(/;\s*Secure/i);
+      });
+    });
+
+    it("does not set Secure flag on OAuth state cookie when FRONTEND_URL is http", async () => {
+      await withFrontendUrl("http://192.168.1.10:30080", async () => {
+        const res = await app.inject({ method: "GET", url: "/api/auth/login" });
+        const setCookie = res.headers["set-cookie"] as string | string[];
+        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+        const stateCookie = cookies.find((c) => c.includes("gha_oauth_state"));
+        expect(stateCookie).not.toMatch(/;\s*Secure/i);
+      });
+    });
   });
 
   // ----------------------------------------------------------------
@@ -196,6 +231,50 @@ describe("Auth routes", () => {
       const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
       const sessionCookieSet = cookies.some((c) => c.includes("gha_session="));
       expect(sessionCookieSet).toBe(true);
+    });
+
+    it("sets Secure flag on session cookie when FRONTEND_URL is https", async () => {
+      await withFrontendUrl("https://example.com", async () => {
+        mockFetchTokenSuccess("ghp_valid", "ghr_refresh", 28800);
+        mockGetAuthenticated.mockResolvedValue({
+          data: { id: 99, login: "alice", avatar_url: "", name: "Alice" },
+        });
+
+        const { stateParam, stateCookie } = await getStateCookie(app);
+        const res = await app.inject({
+          method: "GET",
+          url: `/api/auth/callback?code=validcode&state=${stateParam}`,
+          headers: { cookie: stateCookie },
+        });
+
+        expect(res.statusCode).toBe(302);
+        const setCookie = res.headers["set-cookie"] as string | string[];
+        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+        const sessionCookieHeader = cookies.find((c) => c.includes("gha_session="));
+        expect(sessionCookieHeader).toMatch(/;\s*Secure/i);
+      });
+    });
+
+    it("does not set Secure flag on session cookie when FRONTEND_URL is http", async () => {
+      await withFrontendUrl("http://192.168.1.10:30080", async () => {
+        mockFetchTokenSuccess("ghp_valid", "ghr_refresh", 28800);
+        mockGetAuthenticated.mockResolvedValue({
+          data: { id: 99, login: "alice", avatar_url: "", name: "Alice" },
+        });
+
+        const { stateParam, stateCookie } = await getStateCookie(app);
+        const res = await app.inject({
+          method: "GET",
+          url: `/api/auth/callback?code=validcode&state=${stateParam}`,
+          headers: { cookie: stateCookie },
+        });
+
+        expect(res.statusCode).toBe(302);
+        const setCookie = res.headers["set-cookie"] as string | string[];
+        const cookies = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+        const sessionCookieHeader = cookies.find((c) => c.includes("gha_session="));
+        expect(sessionCookieHeader).not.toMatch(/;\s*Secure/i);
+      });
     });
   });
 

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -19,6 +19,8 @@ const GITHUB_APP_CLIENT_SECRET = () =>
   process.env.GITHUB_APP_CLIENT_SECRET || "";
 const GITHUB_API_URL = () =>
   process.env.GITHUB_API_URL || "https://api.github.com";
+const SECURE_COOKIES = () =>
+  (process.env.FRONTEND_URL || "http://localhost:5173").startsWith("https://");
 
 /** Derive the base web URL from the API URL (handles GHE and github.com). */
 export function githubWebUrl(): string {
@@ -65,7 +67,7 @@ export async function verifySessionToken(
 export function setSessionCookie(reply: FastifyReply, token: string): void {
   reply.setCookie(COOKIE_NAME, token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: SECURE_COOKIES(),
     sameSite: "lax",
     path: "/",
     maxAge: 8 * 60 * 60, // 8 hours
@@ -79,7 +81,7 @@ export function clearSessionCookie(reply: FastifyReply): void {
 export function setOAuthStateCookie(reply: FastifyReply, state: string): void {
   reply.setCookie(OAUTH_STATE_COOKIE, state, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: SECURE_COOKIES(),
     sameSite: "lax",
     path: "/",
     maxAge: 10 * 60, // 10 minutes


### PR DESCRIPTION
## Summary

- Adds a `frontendUrl` Helm value to decouple the OAuth redirect URI and CORS origin from `ingress.host` — previously the only way to set these was via the ingress hostname, which broke deployments where ingress is disabled (NodePort, port-forward, homelab)
- Adds configurable `service.type` for both frontend and backend services (defaults to `ClusterIP`)
- Fixes session/OAuth state cookie `Secure` flag: was previously tied to `NODE_ENV=production`, which broke HTTP non-ingress deploys since browsers refuse to send `Secure` cookies over plain HTTP. Now driven by whether `FRONTEND_URL` starts with `https://`
- Bumps Helm chart to `1.0.1`, default image tags to `v1.0.1`, backend package to `1.0.1`
- Updates README with NodePort deployment instructions, `frontendUrl` documentation, and GitHub App callback URL guidance

## Root Cause

`FRONTEND_URL` and `CORS_ORIGIN` were always derived from `ingress.host` in the ConfigMap template, with no override path for non-ingress deployments. Combined with `secure: true` cookies in production, this made HTTP NodePort/homelab deploys fail OAuth entirely.

## Test plan

- [ ] Helm lint passes: `helm lint deploy/helm/gha-dashboard/`
- [ ] `frontendUrl` override renders correctly in ConfigMap: `helm template ... --set frontendUrl=http://host:port`
- [ ] `service.type=NodePort` renders correctly in both service templates
- [ ] OAuth login works end-to-end on an HTTP NodePort deploy
- [ ] HTTPS ingress deploy still sets `Secure` cookies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)