### PR TITLE
docs: refresh README and split into dedicated docs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,234 +1,92 @@
+<div align="center">
+
 # GHA Dashboard
 
-Single pane of glass for monitoring GitHub Actions workflow statuses across multiple organizations and repositories.
+**A single pane of glass for monitoring GitHub Actions across your organizations**
+
+Track workflow runs · Filter by status, branch, and event · Save named views · Sync across devices
+
+[![Vue](https://img.shields.io/badge/Vue-3-4FC08D?style=flat-square&logo=vue.js&logoColor=white)](https://vuejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://typescriptlang.org)
+[![Fastify](https://img.shields.io/badge/Fastify-5-000000?style=flat-square&logo=fastify&logoColor=white)](https://fastify.dev)
+[![Helm](https://img.shields.io/badge/Helm-chart-0F1689?style=flat-square&logo=helm&logoColor=white)](deploy/helm/gha-dashboard)
+[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)](docker)
+[![CI](https://github.com/shayd3/gha-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/shayd3/gha-dashboard/actions/workflows/ci.yml)
+
+</div>
+
+---
 
 ## Features
 
-- Monitor workflow runs across multiple orgs and repos in one view
-- Filter runs by status, branch, workflow name, or event
-- **Upstream fork runs** — when a selected repo is a fork, workflow runs from the upstream (parent) repo triggered by the authenticated user are automatically fetched and displayed inline with an "upstream" badge. This lets open-source contributors see CI results from upstream repos triggered by their PRs
-- **Named views** — save your current repo selection and filters as a named view, switch instantly from the sidebar, synced across devices via PostgreSQL
-- **Editable views** — modify a view's repos or filters by changing the dashboard while a view is active; a dirty indicator and "Save changes" button appear in the sidebar. Switching views while unsaved prompts to Save & Switch, Discard, or Cancel
+- **Multi-org monitoring** — view workflow runs across multiple organizations and repositories in one place
+- **Upstream fork runs** — when a repo is a fork, runs from the upstream triggered by your user are fetched and shown inline with an "upstream" badge
+- **Named views** — save your current repo selection and filters as a named view, switchable from the sidebar
+- **Editable views** — modify a view's repos or filters on the fly; a dirty indicator and "Save changes" button appear when unsaved
+- **Persistent views** — views sync across devices via PostgreSQL (optional; falls back to in-memory)
+- **GitHub Enterprise** — configurable API URL for GHE and EMU environments
+
+## Quick Start
+
+```bash
+cp .env.example .env   # fill in GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, JWT_SECRET
+docker compose up --build
+```
+
+Open [http://localhost](http://localhost). See [GitHub App Setup](docs/github-app.md) to create the OAuth app first.
 
 ## Tech Stack
 
-- **Frontend**: Vue 3, Vite, PrimeVue, Pinia
-- **Backend**: Fastify, octokit
-- **Auth**: GitHub App (user-to-server OAuth) with JWT session cookies
-- **Database**: PostgreSQL (views persistence)
-- **Shared**: TypeScript types across frontend/backend
-- **Deployment**: Docker, Helm
+| Layer | Technology |
+|-------|-----------|
+| Frontend | Vue 3, Vite, PrimeVue, Pinia |
+| Backend | Fastify, Octokit |
+| Auth | GitHub App (user-to-server OAuth), JWT session cookies |
+| Database | PostgreSQL (optional — views persistence) |
+| Deployment | Docker Compose, Helm (Kubernetes) |
 
 Monorepo managed with pnpm workspaces (`packages/shared`, `packages/backend`, `packages/frontend`).
 
-## Prerequisites
+## Local Development
 
-- Node.js 20+
-- pnpm 10+
-- A [GitHub App](https://github.com/settings/apps) (see **GitHub App Setup** below)
-- PostgreSQL 14+ (optional — for views persistence; without it, views are in-memory only)
-
-## Setup
-
-```bash
-cp .env.example .env
-```
-
-Fill in your `.env`:
-
-```
-GITHUB_APP_CLIENT_ID=...
-GITHUB_APP_CLIENT_SECRET=...
-JWT_SECRET=<random-string>
-# Optional: omit to use in-memory view storage (not persisted across restarts)
-DATABASE_URL=postgresql://gha:gha@localhost:5432/gha_dashboard
-# Optional: for future installation-token features
-# GITHUB_APP_ID=...
-# GITHUB_APP_PRIVATE_KEY=...
-```
-
-Start a local Postgres instance (or use the Docker Compose service):
-
-```bash
-docker compose up db -d
-```
-
-Install and run:
+**Prerequisites:** Node.js 20+, pnpm 10+, a [GitHub App](docs/github-app.md)
 
 ```bash
 pnpm install
 pnpm dev
 ```
 
-This starts the backend on `:3000` and frontend on `:5173`. The Vite dev server proxies `/api` requests to the backend.
+Backend starts on `:3000`, frontend on `:5173`. The Vite dev server proxies `/api` to the backend.
 
-## Project Structure
-
-```
-packages/
-  shared/     Shared TypeScript types
-  backend/    Fastify API — auth, GitHub API proxy, caching, views
-  frontend/   Vue 3 SPA — dashboard UI
-docker/       Dockerfiles + nginx config
-deploy/helm/  Helm chart for K8s deployment
-```
-
-## Environment Variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `GITHUB_APP_CLIENT_ID` | Yes | GitHub App client ID |
-| `GITHUB_APP_CLIENT_SECRET` | Yes | GitHub App client secret |
-| `JWT_SECRET` | Yes | Random string for signing JWT session cookies |
-| `DATABASE_URL` | No | PostgreSQL connection string, e.g. `postgresql://user:pass@localhost:5432/gha_dashboard`. If not set, views are stored in-memory only (not persisted across restarts) and a warning is logged. |
-| `GITHUB_APP_ID` | No | GitHub App numeric ID (reserved for future installation-token features) |
-| `GITHUB_APP_PRIVATE_KEY` | No | GitHub App PEM private key (reserved for future installation-token features) |
-| `GITHUB_API_URL` | No | GitHub Enterprise API endpoint (default: `https://api.github.com`) |
-| `FRONTEND_URL` | No | Where the frontend is served (for OAuth callback & redirect). Default: `http://localhost:5173`. Docker Compose: `http://localhost`. Production: `https://your-domain.com` |
-| `CORS_ORIGIN` | No | Allowed origin for CORS — should match `FRONTEND_URL` (default: `http://localhost:5173`) |
-| `PORT` | No | Backend port (default: `3000`) |
-
-## API Routes
-
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/auth/login` | Redirect to GitHub OAuth |
-| GET | `/api/auth/callback` | OAuth callback, sets session cookie |
-| GET | `/api/auth/me` | Current user info |
-| POST | `/api/auth/logout` | Clear session |
-| GET | `/api/orgs` | List user's organizations |
-| GET | `/api/orgs/:org/repos` | List repos in an org |
-| GET | `/api/repos/:owner/:repo/workflows` | List workflows for a repo |
-| GET | `/api/repos/:owner/:repo/runs` | List runs for a repo |
-| GET | `/api/runs?repos=org/repo1,org/repo2&upstream_repos=upstream/repo:actor:fork/repo` | Aggregated runs across repos (with optional upstream fork runs filtered by actor) |
-| GET | `/api/health` | Health check |
-| GET | `/api/views` | List saved views for the authenticated user |
-| POST | `/api/views` | Create a view (`{ name, repos, filters? }`) — 201 on success, 409 on duplicate name, 400 if over 20-view limit |
-| PUT | `/api/views/:id` | Update a view (name, repos, filters, position) |
-| DELETE | `/api/views/:id` | Delete a view — 204 on success |
-
-## Docker
+Optionally start a local Postgres instance for view persistence:
 
 ```bash
-docker compose up --build
+docker compose up db -d
 ```
 
-Frontend serves on `:80`, backend on `:3000`. Nginx proxies `/api` to the backend container.
+## Documentation
 
-The `db` service runs PostgreSQL 16 and exposes no ports externally. The backend waits for `pg_isready` before starting.
+| Guide | Description |
+|-------|-------------|
+| [GitHub App Setup](docs/github-app.md) | Create and configure the GitHub App for OAuth |
+| [Environment Variables](docs/environment-variables.md) | All supported env vars and their defaults |
+| [Docker](docs/docker.md) | Running with Docker Compose |
+| [Helm](docs/helm.md) | Deploying to Kubernetes with Helm |
+| [API Reference](docs/api.md) | Backend REST API routes |
 
-**Note:** `docker compose down -v` will delete the `pgdata` volume and all stored views.
+## CI & Releases
 
-## Helm
+Two GitHub Actions workflows are included:
 
-```bash
-helm install gha-dashboard ./deploy/helm/gha-dashboard \
-  --set github.appClientId=YOUR_APP_CLIENT_ID \
-  --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
-  --set jwt.secret=YOUR_JWT_SECRET \
-  --set database.url='postgresql://user:pass@your-postgres-host:5432/gha_dashboard' \
-  --set ingress.enabled=true \
-  --set ingress.host=gha-dashboard.your-domain.com
-```
-
-`database.url` is stored in the Kubernetes Secret alongside other credentials. For production, use a managed PostgreSQL service (RDS, Cloud SQL, Azure Database, etc.) and set `database.url` to its connection string. If `database.url` is left empty, the backend falls back to in-memory view storage.
-
-### Deploying without an Ingress (NodePort or port-forward)
-
-When `ingress.enabled` is `false`, set `frontendUrl` explicitly so the OAuth redirect URI and CORS origin are correct:
-
-```bash
-helm install gha-dashboard ./deploy/helm/gha-dashboard \
-  --set github.appClientId=YOUR_APP_CLIENT_ID \
-  --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
-  --set jwt.secret=YOUR_JWT_SECRET \
-  --set frontend.service.type=NodePort \
-  --set frontendUrl=http://YOUR_NODE_HOSTNAME:NODE_PORT
-```
-
-`frontendUrl` defaults to the ingress host when not set. If you're on HTTP (not HTTPS), session cookies are automatically set without the `Secure` flag so they work in plain HTTP environments — `Secure` is only enabled when `frontendUrl` starts with `https://`.
-
-### Service type
-
-Both frontend and backend services default to `ClusterIP`. Override with `frontend.service.type` or `backend.service.type`:
-
-```bash
---set frontend.service.type=NodePort
-```
-
-See `deploy/helm/gha-dashboard/values.yaml` for all configurable values (replicas, resources, TLS, GitHub Enterprise API URL, etc).
-
-## CI And Release Automation
-
-The repository includes two GitHub Actions workflows:
-
-- `CI` runs on pushes to `main`, pull requests targeting `main`, and manual dispatch. It installs dependencies, typechecks the workspace, runs the backend test suite with coverage, and builds all packages.
-- `Release` runs when you push a Git tag matching `v*` (for example `v1.0.1`). It re-runs verification, builds and pushes backend/frontend Docker images to GHCR, packages the Helm chart, publishes it to GHCR as an OCI artifact, and creates a GitHub Release with the chart attached.
+- **CI** — runs on push to `main` and pull requests: typecheck, backend tests, full build
+- **Release** — triggered by `v*` tags: builds and pushes Docker images to GHCR, packages and publishes the Helm chart as an OCI artifact, creates a GitHub Release
 
 To cut a release:
 
 ```bash
-git tag -a v1.0.1 -m "v1.0.1"
+git tag v1.0.1
 git push origin v1.0.1
 ```
 
-By default, images are published to:
-
-- `ghcr.io/shayd3/gha-dashboard-backend`
-- `ghcr.io/shayd3/gha-dashboard-frontend`
-
-The Helm chart is published to:
-
-- `oci://ghcr.io/shayd3/charts/gha-dashboard`
-
-Users can install from the OCI registry directly:
-
-```bash
-helm registry login ghcr.io
-helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
-  --version 1.0.1 \
-  --set github.appClientId=YOUR_APP_CLIENT_ID \
-  --set github.appClientSecret=YOUR_APP_CLIENT_SECRET \
-  --set jwt.secret=YOUR_JWT_SECRET \
-  --set database.url='postgresql://user:pass@host:5432/gha_dashboard' \
-  --set ingress.host=gha-dashboard.example.com
-```
-
-If you prefer, the GitHub Release assets page still includes the packaged chart `.tgz` for manual download and installation.
-
-## Data Persistence
-
-Views are stored in PostgreSQL in the `views` table. The table is created automatically on backend startup via an idempotent `CREATE TABLE IF NOT EXISTS` migration — no migration tool is required.
-
-`DATABASE_URL` is **optional**. If it is not set the backend starts normally, logs a warning, and stores views in-memory — they will be lost on restart. This is convenient for local development or demos where persistence is not needed.
-
-**Local dev with persistence:** `docker compose up db -d` starts a Postgres container. The `DATABASE_URL` in `.env` should point to it.
-
-**Production:** Use a managed PostgreSQL service (AWS RDS, GCP Cloud SQL, Azure Database for PostgreSQL, etc.) and set `DATABASE_URL` (or the Helm `database.url` value) to the connection string. The backend is stateless and horizontally scalable — multiple replicas can share one PostgreSQL instance.
-
-## Caching
-
-In-memory TTL cache (no external dependencies for MVP):
-
-- Orgs/repos: 5 min
-- Workflow runs: 60 sec
-- Upstream fork runs: 60 sec (keyed by upstream repo + actor)
-
-Cache is per-user, keyed by `userId:endpoint`.
-
-## GitHub App Setup
-
-1. Go to **Settings → Developer settings → GitHub Apps → New GitHub App**
-2. Set the **Callback URL** to `http://localhost:5173/api/auth/callback` (for local dev), your production URL, or `http://YOUR_NODE:PORT/api/auth/callback` for NodePort deployments. Must exactly match the `frontendUrl` Helm value + `/api/auth/callback`.
-3. Under **Permissions**:
-   - Repository: **Actions** → Read-only, **Metadata** → Read-only (auto-selected)
-   - Organization: **Members** → Read-only
-4. After creating the app, note the **Client ID** and generate a **Client secret**
-   - User-to-server token expiration is enabled by default for new GitHub Apps — the dashboard handles refresh automatically
-6. Install the app on the organizations/accounts whose repos you want to monitor
-
-> **Note:** Users will only see repos at the intersection of "repos they personally have access to" and "repos where the GitHub App is installed." This is more secure than a blanket OAuth scope.
-
-## GitHub Enterprise
-
-Set `GITHUB_API_URL` in your `.env` to your GHE API endpoint (e.g. `https://github.yourcompany.com/api/v3`). GitHub EMU (Enterprise Managed Users) on github.com is also supported.
+Images are published to `ghcr.io/shayd3/gha-dashboard-{backend,frontend}`.
+Helm chart is published to `oci://ghcr.io/shayd3/charts/gha-dashboard`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,83 @@
+# API Reference
+
+All routes are prefixed with `/api`. Authentication is via an `HttpOnly` session cookie set after OAuth login.
+
+## Auth
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/auth/login` | — | Redirect to GitHub OAuth |
+| `GET` | `/api/auth/callback` | — | OAuth callback — sets session cookie and redirects to frontend |
+| `GET` | `/api/auth/me` | Required | Returns current user info |
+| `POST` | `/api/auth/logout` | — | Clears session cookie |
+
+### `GET /api/auth/me` Response
+
+```json
+{
+  "id": 12345,
+  "login": "octocat",
+  "avatarUrl": "https://avatars.githubusercontent.com/u/12345",
+  "name": "The Octocat"
+}
+```
+
+## Organizations & Repos
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/orgs` | List organizations the authenticated user belongs to |
+| `GET` | `/api/orgs/:org/repos` | List repos in an organization |
+
+## Workflows & Runs
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/repos/:owner/:repo/workflows` | List workflows for a repo |
+| `GET` | `/api/repos/:owner/:repo/runs` | List runs for a repo |
+| `GET` | `/api/runs` | Aggregated runs across multiple repos (see below) |
+
+### `GET /api/runs` Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `repos` | Comma-separated list of `owner/repo` slugs |
+| `upstream_repos` | Comma-separated list of `upstream/repo:actor:fork/repo` triples for upstream fork run fetching |
+
+## Views
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/views` | List saved views for the authenticated user |
+| `POST` | `/api/views` | Create a view — 201 on success, 409 on duplicate name, 400 if over 20-view limit |
+| `PUT` | `/api/views/:id` | Update a view (name, repos, filters, position) |
+| `DELETE` | `/api/views/:id` | Delete a view — 204 on success |
+
+### View Body
+
+```json
+{
+  "name": "My View",
+  "repos": ["org/repo1", "org/repo2"],
+  "filters": {
+    "status": "failure",
+    "branch": "main"
+  }
+}
+```
+
+## Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/health` | Returns `{"status":"ok","timestamp":"..."}` — used for liveness/readiness probes |
+
+## Caching
+
+Responses are cached in-memory per user (keyed by `userId:endpoint`):
+
+| Endpoint | TTL |
+|----------|-----|
+| Orgs / repos | 5 minutes |
+| Workflow runs | 60 seconds |
+| Upstream fork runs | 60 seconds |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,33 @@
+# Docker
+
+## Running with Docker Compose
+
+```bash
+cp .env.example .env  # fill in required values
+docker compose up --build
+```
+
+- Frontend: [http://localhost](http://localhost) (nginx on port 80)
+- Backend: [http://localhost:3000](http://localhost:3000)
+
+The `db` service runs PostgreSQL 16. The backend waits for `pg_isready` before starting.
+
+## Services
+
+| Service | Description |
+|---------|-------------|
+| `frontend` | nginx serving the Vue SPA, proxies `/api` to the backend |
+| `backend` | Fastify API |
+| `db` | PostgreSQL 16 (no external port exposed) |
+
+## Stopping
+
+```bash
+docker compose down
+```
+
+> **Warning:** `docker compose down -v` will delete the `pgdata` volume and all stored views.
+
+## Running Without the Database
+
+Leave `DATABASE_URL` unset in your `.env`. The backend starts normally, logs a warning, and stores views in-memory only.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,28 @@
+# Environment Variables
+
+## Required
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_APP_CLIENT_ID` | GitHub App client ID |
+| `GITHUB_APP_CLIENT_SECRET` | GitHub App client secret |
+| `JWT_SECRET` | Random string used to sign JWT session cookies |
+
+## Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | _(none)_ | PostgreSQL connection string, e.g. `postgresql://user:pass@localhost:5432/gha_dashboard`. If not set, views are stored in-memory and lost on restart. |
+| `FRONTEND_URL` | `http://localhost:5173` | Where the frontend is served — used for the OAuth `redirect_uri` and post-login redirect. Must match the callback URL registered in your GitHub App. |
+| `CORS_ORIGIN` | `http://localhost:5173` | Allowed origin for CORS. Should match `FRONTEND_URL`. |
+| `GITHUB_API_URL` | `https://api.github.com` | GitHub API base URL. Override for GitHub Enterprise (e.g. `https://github.yourcompany.com/api/v3`). |
+| `PORT` | `3000` | Port the backend listens on. |
+| `NODE_ENV` | `development` | Set to `production` in deployed environments. |
+| `GITHUB_APP_ID` | _(none)_ | GitHub App numeric ID. Reserved for future installation-token features. |
+| `GITHUB_APP_PRIVATE_KEY` | _(none)_ | GitHub App PEM private key. Reserved for future installation-token features. |
+
+## Notes
+
+- **`FRONTEND_URL` and secure cookies** — The `Secure` cookie flag is set based on whether `FRONTEND_URL` starts with `https://`. HTTP deployments (local dev, NodePort without TLS) do not need any special configuration.
+- **Helm deployments** — These variables are managed via the Helm `values.yaml` and a ConfigMap/Secret. See [Helm docs](helm.md) for how they map to chart values.
+- **Docker Compose** — Pass these via the `.env` file at the repo root. See [Docker docs](docker.md).

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,58 @@
+# GitHub App Setup
+
+GHA Dashboard authenticates users via a GitHub App using user-to-server OAuth. You need to create one before running the app.
+
+## Creating the App
+
+1. Go to **Settings → Developer settings → GitHub Apps → New GitHub App**
+2. Fill in the fields:
+
+   | Field | Value |
+   |-------|-------|
+   | GitHub App name | Anything (e.g. `gha-dashboard-local`) |
+   | Homepage URL | `http://localhost:5173` (or your deployed URL) |
+   | Callback URL | `http://localhost:5173/api/auth/callback` (see [Callback URL](#callback-url)) |
+   | Webhook | Uncheck "Active" — not needed |
+
+3. Under **Permissions**, set:
+
+   | Permission | Level |
+   |-----------|-------|
+   | Repository → Actions | Read-only |
+   | Repository → Metadata | Read-only (auto-selected) |
+   | Organization → Members | Read-only |
+
+4. Set **"Where can this GitHub App be installed?"** to **Any account** if you want to monitor orgs you don't own.
+
+5. Click **Create GitHub App**.
+
+6. On the app page, note the **Client ID** and generate a **Client secret** — you'll need both for your `.env`.
+
+7. **Install the app** on every organization or account whose repos you want to monitor (Settings → Install App).
+
+> **Note:** Users will only see repos at the intersection of "repos they personally have access to" and "repos where the GitHub App is installed."
+
+## Callback URL
+
+The callback URL must exactly match what the backend sends as `redirect_uri`. It is constructed as:
+
+```
+{FRONTEND_URL}/api/auth/callback
+```
+
+| Deployment | FRONTEND_URL | Callback URL to register |
+|-----------|--------------|--------------------------|
+| Local dev | `http://localhost:5173` | `http://localhost:5173/api/auth/callback` |
+| Docker Compose | `http://localhost` | `http://localhost/api/auth/callback` |
+| Helm + Ingress | `https://gha-dashboard.example.com` | `https://gha-dashboard.example.com/api/auth/callback` |
+| Helm + NodePort | `http://your-node:31515` | `http://your-node:31515/api/auth/callback` |
+
+You can register multiple callback URLs in the GitHub App settings using the **Add Callback URL** button — useful if you run the app in multiple environments with the same App.
+
+## Token Expiration
+
+User-to-server token expiration is enabled by default for new GitHub Apps. GHA Dashboard handles refresh automatically — no action required.
+
+## GitHub Enterprise
+
+Set `GITHUB_API_URL` to your GHE endpoint (e.g. `https://github.yourcompany.com/api/v3`). GitHub EMU (Enterprise Managed Users) on github.com is also supported.

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,0 +1,108 @@
+# Helm Deployment
+
+## Prerequisites
+
+- Kubernetes cluster with an nginx ingress controller (for ingress deployments)
+- Helm 3.x
+- A configured [GitHub App](github-app.md)
+
+## Install from OCI Registry
+
+```bash
+helm registry login ghcr.io
+helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
+  --version 1.0.1 \
+  --namespace gha-dashboard --create-namespace \
+  --set github.appClientId=YOUR_CLIENT_ID \
+  --set github.appClientSecret=YOUR_CLIENT_SECRET \
+  --set jwt.secret=YOUR_JWT_SECRET \
+  --set ingress.enabled=true \
+  --set ingress.host=gha-dashboard.example.com
+```
+
+## Install from Source
+
+```bash
+helm install gha-dashboard ./deploy/helm/gha-dashboard \
+  --namespace gha-dashboard --create-namespace \
+  --set github.appClientId=YOUR_CLIENT_ID \
+  --set github.appClientSecret=YOUR_CLIENT_SECRET \
+  --set jwt.secret=YOUR_JWT_SECRET \
+  --set ingress.enabled=true \
+  --set ingress.host=gha-dashboard.example.com
+```
+
+## Deploying Without an Ingress (NodePort)
+
+When `ingress.enabled` is `false`, set `frontendUrl` explicitly so the OAuth redirect URI and CORS origin are correct:
+
+```bash
+helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
+  --version 1.0.1 \
+  --namespace gha-dashboard --create-namespace \
+  --set github.appClientId=YOUR_CLIENT_ID \
+  --set github.appClientSecret=YOUR_CLIENT_SECRET \
+  --set jwt.secret=YOUR_JWT_SECRET \
+  --set frontend.service.type=NodePort \
+  --set frontendUrl=http://YOUR_NODE:NODE_PORT
+```
+
+Then check the assigned NodePort:
+
+```bash
+kubectl get svc gha-dashboard-frontend -n gha-dashboard
+```
+
+Register `http://YOUR_NODE:NODE_PORT/api/auth/callback` as the callback URL in your GitHub App.
+
+## With PostgreSQL
+
+```bash
+--set database.url='postgresql://user:pass@host:5432/gha_dashboard'
+```
+
+`database.url` is stored in a Kubernetes Secret. If omitted, views are stored in-memory only.
+
+## TLS
+
+```bash
+--set ingress.tls.enabled=true \
+--set ingress.tls.secretName=gha-dashboard-tls \
+--set ingress.host=gha-dashboard.example.com
+```
+
+Provision the TLS secret separately (e.g. via cert-manager).
+
+## Key Values Reference
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `frontend.service.type` | `ClusterIP` | Service type for the frontend (`ClusterIP`, `NodePort`) |
+| `backend.service.type` | `ClusterIP` | Service type for the backend |
+| `frontendUrl` | _(derived from ingress host)_ | Explicit URL for OAuth redirect and CORS. Required when ingress is disabled. |
+| `ingress.enabled` | `false` | Enable nginx Ingress |
+| `ingress.host` | `gha-dashboard.example.com` | Ingress hostname |
+| `ingress.tls.enabled` | `false` | Enable TLS on the Ingress |
+| `github.appClientId` | `""` | GitHub App client ID |
+| `github.appClientSecret` | `""` | GitHub App client secret |
+| `jwt.secret` | `""` | JWT signing secret |
+| `database.url` | `""` | PostgreSQL connection string |
+| `github.apiUrl` | `https://api.github.com` | GitHub API URL (override for GHE) |
+
+See [`values.yaml`](../deploy/helm/gha-dashboard/values.yaml) for the full list including resource limits and replica counts.
+
+## Upgrading
+
+```bash
+helm upgrade gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
+  --version 1.0.1 \
+  --namespace gha-dashboard \
+  --reuse-values
+```
+
+## Validating a Local Chart
+
+```bash
+helm lint deploy/helm/gha-dashboard/
+helm template gha-dashboard deploy/helm/gha-dashboard/ --set github.appClientId=test
+```


### PR DESCRIPTION
## Summary

- Redesigns the README with a centered header, shields.io badges, and a concise structure inspired by [arbitrage-bot](https://github.com/shayd3/arbitrage-bot)
- Moves detailed documentation out of the README into a `docs/` folder to keep the landing page scannable

## New docs structure

| File | Contents |
|------|----------|
| `docs/github-app.md` | Step-by-step GitHub App creation, permissions, and callback URL guide |
| `docs/environment-variables.md` | All supported env vars with defaults and notes |
| `docs/docker.md` | Docker Compose usage |
| `docs/helm.md` | Helm deployment — ingress, NodePort, OCI registry, TLS, values reference |
| `docs/api.md` | Full REST API reference with routes, params, and response shapes |

## Test plan
- [ ] All links in README resolve correctly
- [ ] Docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)