### PR TITLE
fix(helm): support explicit nodePort for stable NodePort services

### DIFF
--- a/deploy/helm/gha-dashboard/Chart.yaml
+++ b/deploy/helm/gha-dashboard/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gha-dashboard
 description: GitHub Actions Dashboard - Monitor workflow statuses across organizations
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.0.1"

--- a/deploy/helm/gha-dashboard/templates/service-backend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-backend.yaml
@@ -11,6 +11,9 @@ spec:
   ports:
     - port: {{ .Values.backend.service.port }}
       targetPort: {{ .Values.backend.service.port }}
+      {{- if and (eq (default "ClusterIP" .Values.backend.service.type) "NodePort") .Values.backend.service.nodePort }}
+      nodePort: {{ .Values.backend.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: backend

--- a/deploy/helm/gha-dashboard/templates/service-backend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-backend.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: backend
+{{- if and .Values.backend.service.nodePort (ne (default "ClusterIP" .Values.backend.service.type) "NodePort") }}
+{{- fail "backend.service.nodePort is set but backend.service.type is not NodePort" }}
+{{- end }}
 spec:
   type: {{ default "ClusterIP" .Values.backend.service.type }}
   ports:

--- a/deploy/helm/gha-dashboard/templates/service-frontend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-frontend.yaml
@@ -11,6 +11,9 @@ spec:
   ports:
     - port: {{ .Values.frontend.service.port }}
       targetPort: 80
+      {{- if and (eq (default "ClusterIP" .Values.frontend.service.type) "NodePort") .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: frontend

--- a/deploy/helm/gha-dashboard/templates/service-frontend.yaml
+++ b/deploy/helm/gha-dashboard/templates/service-frontend.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: frontend
+{{- if and .Values.frontend.service.nodePort (ne (default "ClusterIP" .Values.frontend.service.type) "NodePort") }}
+{{- fail "frontend.service.nodePort is set but frontend.service.type is not NodePort" }}
+{{- end }}
 spec:
   type: {{ default "ClusterIP" .Values.frontend.service.type }}
   ports:

--- a/deploy/helm/gha-dashboard/values.yaml
+++ b/deploy/helm/gha-dashboard/values.yaml
@@ -7,6 +7,7 @@ frontend:
   service:
     type: ClusterIP
     port: 80
+    # nodePort: 31515  # Set when type is NodePort for a stable port
   resources:
     limits:
       cpu: 100m
@@ -24,6 +25,7 @@ backend:
   service:
     type: ClusterIP
     port: 3000
+    # nodePort: 31000  # Set when type is NodePort for a stable port
   resources:
     limits:
       cpu: 500m

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -11,7 +11,7 @@
 ```bash
 helm registry login ghcr.io
 helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
-  --version 1.0.1 \
+  --version 1.0.2 \
   --namespace gha-dashboard --create-namespace \
   --set github.appClientId=YOUR_CLIENT_ID \
   --set github.appClientSecret=YOUR_CLIENT_SECRET \
@@ -34,20 +34,23 @@ helm install gha-dashboard ./deploy/helm/gha-dashboard \
 
 ## Deploying Without an Ingress (NodePort)
 
-When `ingress.enabled` is `false`, set `frontendUrl` explicitly so the OAuth redirect URI and CORS origin are correct:
+When `ingress.enabled` is `false`, set `frontendUrl` explicitly so the OAuth redirect URI and CORS origin are correct.
+
+To pin stable ports (recommended — avoids random port reassignment on Service recreate):
 
 ```bash
 helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
-  --version 1.0.1 \
+  --version 1.0.2 \
   --namespace gha-dashboard --create-namespace \
   --set github.appClientId=YOUR_CLIENT_ID \
   --set github.appClientSecret=YOUR_CLIENT_SECRET \
   --set jwt.secret=YOUR_JWT_SECRET \
   --set frontend.service.type=NodePort \
-  --set frontendUrl=http://YOUR_NODE:NODE_PORT
+  --set frontend.service.nodePort=31515 \
+  --set frontendUrl=http://YOUR_NODE:31515
 ```
 
-Then check the assigned NodePort:
+If you omit `nodePort`, Kubernetes auto-assigns a port from the `30000–32767` range. Check the assigned port with:
 
 ```bash
 kubectl get svc gha-dashboard-frontend -n gha-dashboard
@@ -78,7 +81,9 @@ Provision the TLS secret separately (e.g. via cert-manager).
 | Value | Default | Description |
 |-------|---------|-------------|
 | `frontend.service.type` | `ClusterIP` | Service type for the frontend (`ClusterIP`, `NodePort`) |
-| `backend.service.type` | `ClusterIP` | Service type for the backend |
+| `frontend.service.nodePort` | _(unset)_ | Pin a specific NodePort for the frontend (30000–32767); auto-assigned if omitted |
+| `backend.service.type` | `ClusterIP` | Service type for the backend (`ClusterIP`, `NodePort`) |
+| `backend.service.nodePort` | _(unset)_ | Pin a specific NodePort for the backend (30000–32767); auto-assigned if omitted |
 | `frontendUrl` | _(derived from ingress host)_ | Explicit URL for OAuth redirect and CORS. Required when ingress is disabled. |
 | `ingress.enabled` | `false` | Enable nginx Ingress |
 | `ingress.host` | `gha-dashboard.example.com` | Ingress hostname |
@@ -95,7 +100,7 @@ See [`values.yaml`](../deploy/helm/gha-dashboard/values.yaml) for the full list 
 
 ```bash
 helm upgrade gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
-  --version 1.0.1 \
+  --version 1.0.2 \
   --namespace gha-dashboard \
   --reuse-values
 ```

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -47,6 +47,8 @@ helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
   --set jwt.secret=YOUR_JWT_SECRET \
   --set frontend.service.type=NodePort \
   --set frontend.service.nodePort=31515 \
+  --set backend.service.type=NodePort \
+  --set backend.service.nodePort=31000 \
   --set frontendUrl=http://YOUR_NODE:31515
 ```
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -52,13 +52,15 @@ helm install gha-dashboard oci://ghcr.io/shayd3/charts/gha-dashboard \
   --set frontendUrl=http://YOUR_NODE:31515
 ```
 
-If you omit `nodePort`, Kubernetes auto-assigns a port from the `30000–32767` range. Check the assigned port with:
+Register `http://YOUR_NODE:31515/api/auth/callback` as the callback URL in your GitHub App (substitute the port you chose for `frontend.service.nodePort`).
+
+If you omit `nodePort`, Kubernetes auto-assigns a port from the `30000–32767` range. Find the assigned port with:
 
 ```bash
 kubectl get svc gha-dashboard-frontend -n gha-dashboard
 ```
 
-Register `http://YOUR_NODE:NODE_PORT/api/auth/callback` as the callback URL in your GitHub App.
+Then register `http://YOUR_NODE:<assigned-port>/api/auth/callback` as the callback URL.
 
 ## With PostgreSQL
 


### PR DESCRIPTION
## Summary

- Adds optional `nodePort` field to both `service-backend.yaml` and `service-frontend.yaml` templates — rendered when provided, omitted otherwise (Kubernetes auto-assigns)
- Adds commented `# nodePort:` hints in `values.yaml` to make the option discoverable
- Bumps Chart version `1.0.1` → `1.0.2`
- Updates `docs/helm.md`: NodePort section now shows pinning a stable port; values table includes the new fields

## Test plan

- [ ] `helm template test deploy/helm/gha-dashboard/` — no `nodePort` field in either service (ClusterIP default)
- [ ] `helm template ... --set backend.service.type=NodePort` — renders without `nodePort` (auto-assign)
- [ ] `helm template ... --set backend.service.type=NodePort --set backend.service.nodePort=31000` — renders `nodePort: 31000`
- [ ] `helm template ... --set frontend.service.type=LoadBalancer` — no `nodePort` field, no error
- [ ] `helm lint deploy/helm/gha-dashboard/` — passes

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)